### PR TITLE
Ensure sequential file prompts and add tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "react": "^19.1.1",
@@ -16,6 +17,7 @@
   "devDependencies": {
     "@types/node": "^22.14.0",
     "typescript": "~5.8.2",
-    "vite": "^6.2.0"
+    "vite": "^6.2.0",
+    "vitest": "^2.1.1"
   }
 }

--- a/services/geminiService.test.ts
+++ b/services/geminiService.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { buildPrompt } from './geminiService';
+import { CommandId, Command, UploadedFile } from '../types';
+
+describe('buildPrompt', () => {
+  it('orders multiple file parts with start and end markers', async () => {
+    const command: Command = {
+      id: CommandId.REVIEW,
+      name: 'Review',
+      description: '',
+      files: [
+        { id: 'rfp', label: 'RFP', accept: ['.txt'] },
+        { id: 'cs', label: 'Capability Statement', accept: ['.txt'] },
+      ],
+    };
+
+    const files: Record<string, UploadedFile> = {
+      rfp: { name: 'rfp.txt', type: 'text/plain', size: 1, content: 'RFP_CONTENT' },
+      cs: { name: 'cs.txt', type: 'text/plain', size: 1, content: 'CS_CONTENT' },
+    };
+
+    const parts = await buildPrompt(command, {}, files);
+
+    expect(parts[0]).toBe(`Command: ${command.id}\n`);
+    expect(parts[1]).toEqual({ text: '--- START RFP ---\n' });
+    expect(parts[2]).toEqual({ inlineData: { mimeType: 'text/plain', data: 'RFP_CONTENT' } });
+    expect(parts[3]).toEqual({ text: '\n--- END RFP ---\n' });
+    expect(parts[4]).toEqual({ text: '--- START CAPABILITY STATEMENT ---\n' });
+    expect(parts[5]).toEqual({ inlineData: { mimeType: 'text/plain', data: 'CS_CONTENT' } });
+    expect(parts[6]).toEqual({ text: '\n--- END CAPABILITY STATEMENT ---\n' });
+    expect(parts[parts.length - 1].text.startsWith('\nInstruction:')).toBe(true);
+  });
+});

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -20,7 +20,7 @@ const fileToGenerativePart = async (file: UploadedFile) => {
 const MASTER_SYSTEM_PROMPT = `You are the FGA Omni-Assistant, a sophisticated AI specialized in U.S. Federal Government procurement. Your purpose is to assist federal government advisors and procurement specialists. You must be professional, analytical, and precise. Your outputs should be well-structured, clear, and ready for a professional business context. Do not use emojis. Respond in Markdown format.`;
 
 
-const buildPrompt = async (command: Command, inputs: Record<string, string>, files: Record<string, UploadedFile>): Promise<any[]> => {
+export const buildPrompt = async (command: Command, inputs: Record<string, string>, files: Record<string, UploadedFile>): Promise<any[]> => {
   let userPrompt = `Command: ${command.id}\n`;
 
   for (const key in inputs) {
@@ -33,9 +33,9 @@ const buildPrompt = async (command: Command, inputs: Record<string, string>, fil
       const file = files[key];
       const filePart = await fileToGenerativePart(file);
       const label = command.files?.find(f => f.id === key)?.label || 'Document';
-      parts.unshift({text: `--- START ${label.toUpperCase()} ---\n`});
-      parts.push({text: `\n--- END ${label.toUpperCase()} ---\n`});
-      parts.splice(parts.length -1, 0, filePart);
+      parts.push({ text: `--- START ${label.toUpperCase()} ---\n` });
+      parts.push(filePart);
+      parts.push({ text: `\n--- END ${label.toUpperCase()} ---\n` });
   }
 
   let specificInstruction = '';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,8 @@
     ],
     "skipLibCheck": true,
     "types": [
-      "node"
+      "node",
+      "vitest"
     ],
     "moduleResolution": "bundler",
     "isolatedModules": true,


### PR DESCRIPTION
## Summary
- Push start marker, file part, and end marker in sequence for each uploaded file
- Expose `buildPrompt` for testing and cover ordering logic with unit tests
- Configure Vitest testing framework

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a8500c4b3883318da738838e23a9f0