### PR TITLE
Switch to VITE_GEMINI_API_KEY environment variable

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,0 +1,2 @@
+# Gemini API key
+VITE_GEMINI_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+!.env.local
 
 # Editor directories and files
 .vscode/*

--- a/README.md
+++ b/README.md
@@ -15,6 +15,6 @@ View your app in AI Studio: https://ai.studio/apps/drive/1LOHa06PrZwjI6k456iVQYd
 
 1. Install dependencies:
    `npm install`
-2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
+2. Set the `VITE_GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
 3. Run the app:
    `npm run dev`

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -2,11 +2,15 @@
 import { GoogleGenAI } from "@google/genai";
 import { Command, CommandId, UploadedFile } from '../types';
 
-if (!process.env.API_KEY) {
-  throw new Error("API_KEY environment variable not set");
+const API_KEY = import.meta.env.VITE_GEMINI_API_KEY;
+
+if (!API_KEY) {
+  console.warn(
+    "VITE_GEMINI_API_KEY environment variable not set. Please add it to your .env.local file.",
+  );
 }
 
-const ai = new GoogleGenAI({ apiKey: process.env.API_KEY });
+const ai = API_KEY ? new GoogleGenAI({ apiKey: API_KEY }) : null;
 
 const fileToGenerativePart = async (file: UploadedFile) => {
   return {
@@ -66,7 +70,13 @@ export const runCommand = async (
   inputs: Record<string, string>,
   files: Record<string, UploadedFile>
 ): Promise<AsyncIterable<string>> => {
-    
+
+  if (!ai) {
+    throw new Error(
+      "Missing VITE_GEMINI_API_KEY. Set it in your environment to use this service.",
+    );
+  }
+
   const promptParts = await buildPrompt(command, inputs, files);
   
   const model = ai.models['gemini-2.5-flash'];

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,8 +5,7 @@ export default defineConfig(({ mode }) => {
     const env = loadEnv(mode, '.', '');
     return {
       define: {
-        'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
-        'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)
+        'import.meta.env.VITE_GEMINI_API_KEY': JSON.stringify(env.VITE_GEMINI_API_KEY),
       },
       resolve: {
         alias: {


### PR DESCRIPTION
## Summary
- use `import.meta.env.VITE_GEMINI_API_KEY` instead of `process.env.API_KEY`
- warn and throw errors when the Gemini API key is missing
- document `VITE_GEMINI_API_KEY` in `.env.local` and README and expose it via Vite config

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a84fb74d288331a8e1e1e76a24b4c5