### PR TITLE
Handle file extensions case-insensitively in uploads

### DIFF
--- a/components/FileUpload.tsx
+++ b/components/FileUpload.tsx
@@ -29,7 +29,7 @@ export const FileUpload: React.FC<FileUploadProps> = ({ id, accept, file, onFile
 
   const handleFile = useCallback(async (selectedFile: File | null) => {
     if (selectedFile) {
-      if (!accept.some(type => selectedFile.name.endsWith(type))) {
+      if (!accept.some(type => selectedFile.name.toLowerCase().endsWith(type.toLowerCase()))) {
         alert(`Invalid file type. Please upload one of: ${accept.join(', ')}`);
         return;
       }


### PR DESCRIPTION
## Summary
- Ensure file type validation compares lowercased filenames and extensions

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a85c331c3c833188b5d33f80757983